### PR TITLE
PR: Fix broken build badge in `README.md` #123 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/grisp/grisp/actions/workflows/continous_integration.yaml?query=branch%3Amaster">
-    <img alt="continous integration" src="https://img.shields.io/github/workflow/status/grisp/grisp/Continuous%20Integration?style=flat-square"/>
+    <img alt="continous integration" src="https://img.shields.io/github/actions/workflow/status/grisp/grisp/continous_integration.yaml?label=build&style=flat-square&branch=master"/>
   </a>
   <a href="https://hex.pm/packages/grisp">
     <img alt="hex.pm version" src="https://img.shields.io/hexpm/v/grisp.svg?style=flat-square"/>


### PR DESCRIPTION
1-line PR
+ [x] Fix the broken build badge in `README.md` #123 

![grisp-build-badge-broken](https://github.com/grisp/grisp/assets/194400/b08bbb19-d21e-4808-b338-2e24ada62574)

From: 

[![continous integration](https://img.shields.io/github/workflow/status/grisp/grisp/Continuous%20Integration?style=flat-square)](https://github.com/grisp/grisp/actions/workflows/continous_integration.yaml)

To:

[![continous integration](https://img.shields.io/github/actions/workflow/status/grisp/grisp/continous_integration.yaml?label=build&style=flat-square&branch=master)](https://github.com/grisp/grisp/actions/workflows/continous_integration.yaml)
